### PR TITLE
Added doc for custom fields

### DIFF
--- a/source/includes_main/_custom_fields.md
+++ b/source/includes_main/_custom_fields.md
@@ -58,12 +58,7 @@ curl -X GET "https://api.prospect.io/public/v1/custom_fields" \
         ...
       }
     }
-  ],
-  "links": {
-    "self": "https://api.prospect.io/public/v1/custom_fields/?page%5Bnumber%5D=1&page%5Bsize%5D=100",
-    "next": "https://api.prospect.io/public/v1/custom_fields/?page%5Bnumber%5D=2&page%5Bsize%5D=100",
-    "last": "https://api.prospect.io/public/v1/custom_fields/?page%5Bnumber%5D=5&page%5Bsize%5D=100"
-  }
+  ]
 }
 ```
 

--- a/source/includes_main/_custom_fields.md
+++ b/source/includes_main/_custom_fields.md
@@ -1,0 +1,70 @@
+# Custom Fields
+## The custom field object
+```
+# EXAMPLE OBJECT
+```
+
+```json
+{
+  "data": {
+    "id": "1",
+    "type": "custom_fields",
+    "attributes": {
+      "identifier": "c_custom_field_a",
+      "name": "Lead Value",
+      "value_type": "text"
+    }
+  }
+}
+```
+
+### Object attributes
+Attribute | Filterable? | Description
+--------- | ----------- | -----------
+id | no | **string** <br />A UUID key for the custom field
+identifier | no | **string** <br />The custom field's `identifier` **to be used as attribute key into prospect objects' payload**
+name | no | **string** <br />The custom field's name/label
+value_type | no | **string** <br />The custom field's value type, can be one of the following: `numeric`, `text`, `text_long`, `phone`, `url`, `boolean`, `list_single`, `list_multiple`, `datetime`
+
+
+## List Custom Fields
+
+```shell
+# DEFINITION
+GET https://api.prospect.io/public/v1/custom_fields
+
+# EXAMPLE
+curl -X GET "https://api.prospect.io/public/v1/custom_fields" \
+-H "Authorization: your_api_key" \
+-H "Content-Type: application/vnd.api+json; charset=utf-8" \
+```
+
+> The above command returns JSON structured like this:
+
+```json
+{
+  "data": [
+    {
+      "id": "1",
+      "type": "custom_fields",
+      "attributes": {
+        ...
+      }
+    },
+    {
+      "id": "2",
+      "type": "custom_fields",
+      "attributes": {
+        ...
+      }
+    }
+  ],
+  "links": {
+    "self": "https://api.prospect.io/public/v1/custom_fields/?page%5Bnumber%5D=1&page%5Bsize%5D=100",
+    "next": "https://api.prospect.io/public/v1/custom_fields/?page%5Bnumber%5D=2&page%5Bsize%5D=100",
+    "last": "https://api.prospect.io/public/v1/custom_fields/?page%5Bnumber%5D=5&page%5Bsize%5D=100"
+  }
+}
+```
+
+Returns all custom fields.

--- a/source/includes_main/_prospects.md
+++ b/source/includes_main/_prospects.md
@@ -107,9 +107,9 @@ updated_at | no | **datetime** | ISO 8601 format with timezone offset
 
 ### Custom Fields
 
-Custom fields allow you to store more specific information about your prospects, they can be defined into [your settings](https://app.prospect.io/settings/custom-fields).
+Custom fields can be used as normal attributes by using their `identifier` as attribute key, see the `c_custom_field_a` example in the above payload.
 
-Use the `identifier` of your custom fields as attribute keys.
+You can retrieve the list of your custom fields by using the [custom fields index endpoint](#list-custom-fields)
 
 ### Relationships
 Object | Description

--- a/source/includes_main/_prospects.md
+++ b/source/includes_main/_prospects.md
@@ -24,11 +24,7 @@
       "state": "Walloon Brabant",
       "city": "Wavre",
       "industry": "IT",
-      "custom_field_a": "Hot lead",
-      "custom_field_b": null,
-      "custom_field_c": null,
-      "custom_field_d": null,
-      "custom_field_e": null,
+      "c_custom_field_a": "Hot lead",
       "created_from": "extension",
       "last_emailed_at": null,
       "converted": false,
@@ -92,7 +88,6 @@ country | **yes** | **string** <br />The prospect's country
 state | **yes** | **string** <br />The prospect's state or region
 city | **yes** | **string** <br />The prospect's city
 industry | **yes** | **string** <br />The prospect's industry
-custom_field_[a..e] | **yes** | **string** <br />Five custom fields (custom_field_a, custom_field_b, ...) that you can use freely
 created_from | no | **string** <br />The source of the prospect. Can be `web`, `extension`, `api` or `import`
 last_emailed_at | no | **datetime** <br />The date and time of the last email sent to this prospect in ISO 8601 format with timezone offset
 converted | **yes** | **boolean** <br />Whether or not the prospect is marked as converted
@@ -110,6 +105,12 @@ list_name | no | **string** <br />The name of the list if the prospect is in a l
 created_at | no | **datetime** | ISO 8601 format with timezone offset
 updated_at | no | **datetime** | ISO 8601 format with timezone offset
 
+### Custom Fields
+
+Custom fields allow you to store more specific information about your prospects, they can be defined into [your settings](https://app.prospect.io/settings/custom-fields).
+
+Use the `identifier` of your custom fields as attribute keys.
+
 ### Relationships
 Object | Description
 --------- | -----------
@@ -118,6 +119,7 @@ responsible | The [user](#users) responsible of the prospect
 list | Describe a [list object](#lists) if the prospect is in a list
 campaign | Describe a [campaign object](#campaign) if the prospect is currently in a campaign. The campaign status is described in the `campaign_status` attribute
 current_campaign_subscription | Describe a [campaign subscription](#campaign-subscriptions) if the prospect is currently in a campaign.
+
 
 ## Create a prospect
 ```shell
@@ -159,7 +161,6 @@ country<br />*string* | *NULL* | The prospect's country
 state<br />*string* | *NULL* | The prospect's state or region
 city<br />*string* | *NULL* | The prospect's city
 industry<br />*string* | *NULL* | The prospect's industry
-custom_field_[a..e]<br /> *string* | *NULL* | Five custom fields (custom_field_a, custom_field_b, ...) that you can use freely
 list_id<br />*integer* | *NULL* | ID of the list where to save the prospect
 responsible_id<br />*integer* | ID of the user who created the prospect | The ID of the user responsible for this prospect
 
@@ -224,7 +225,6 @@ country<br />*string* | The prospect's country
 state<br />*string* | *NULL* | The prospect's state or region
 city<br />*string* | *NULL* | The prospect's city
 industry<br />*string* | The prospect's industry
-custom_field_[a..e]<br /> | *string* | Five custom fields (custom_field_a, custom_field_b, ...) that you can use freely
 list_id<br />*integer* | ID of the list where to save the prospect
 responsible_id<br />*integer* | The ID of the user responsible for this prospect
 

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -18,6 +18,7 @@ includes:
 includes_main:
   - account
   - prospects
+  - custom_fields
   - lists
   - campaigns
   - campaign_steps


### PR DESCRIPTION
This adds the doc for the new custom fields index endpoint and the new way we return custom fields into prospects payload.  

<img width="1920" alt="Capture d’écran 2019-11-04 à 16 11 37" src="https://user-images.githubusercontent.com/14982869/68131809-fde09880-ff1d-11e9-83d6-a799b2898644.png">
<img width="818" alt="Capture d’écran 2019-11-04 à 16 11 57" src="https://user-images.githubusercontent.com/14982869/68131808-fde09880-ff1d-11e9-8c3f-86ce3e6a3b24.png">

