### PR TITLE
Add documentation about organization

### DIFF
--- a/source/includes/_relationships.md
+++ b/source/includes/_relationships.md
@@ -1,0 +1,69 @@
+# Relationships
+```shell
+# EXAMPLE
+GET https://api.prospect.io/public/v1/prospects/?include=organization
+```
+
+> Get prospects with their associated organizations
+
+Resources returned by the API are returned in the JSON API format, which means that related entities are 
+linked using a "relationship" section in the JSON payloads. 
+This section only contains the links between the unique identifier of related records (in the example, Prospect#29964 and Organization#1). 
+
+In order to get access to associated information on an entity, you can use the parameter `?include=`, which will create 
+a new section "included" containing the full payload of all the associated data. 
+
+```shell
+# RETURNS
+{
+    "data": {
+        "id": "29964",
+        "type": "prospects",
+        "attributes": {
+            …
+        },
+        "relationships": {
+            "creator": {
+                "data": {
+                    "id": "181",
+                    "type": "users"
+                }
+            },
+            "responsible": {
+                "data": {
+                    "id": "181",
+                    "type": "users"
+                }
+            },
+            "organization": {
+                "data": {
+                    "id": "1",
+                    "type": "organizations"
+                }
+            }
+        }
+    },
+    "included": [
+        {
+            "id": "1",
+            "type": "organizations",
+            "attributes": {
+                "name": "Prospect.io",
+                "created_at": "2020-11-06T13:56:44Z",
+                "updated_at": "2020-11-06T13:56:44Z",
+                "updater_id": 181,
+                "creator_id": 181,
+                "website": null,
+                "phone": null,
+                "email": null,
+                "country": null,
+                "city": null,
+                "state": null,
+                "address": null,
+                "description": null,
+                "lists": []
+            }
+        }
+    ]
+}
+```

--- a/source/includes/_relationships.md
+++ b/source/includes/_relationships.md
@@ -1,7 +1,7 @@
 # Relationships
 ```shell
 # EXAMPLE
-GET https://api.prospect.io/public/v1/prospects/?include=organization
+GET https://api.prospect.io/public/v1/prospects?include=organization
 ```
 
 > Get prospects with their associated organizations
@@ -11,7 +11,8 @@ linked using a "relationship" section in the JSON payloads.
 This section only contains the links between the unique identifier of related records (in the example, Prospect#29964 and Organization#1). 
 
 In order to get access to associated information on an entity, you can use the parameter `?include=`, which will create 
-a new section "included" containing the full payload of all the associated data. 
+a new section "included" containing the full payload of all the associated data. Notice that you can include multiple 
+relationships by joining them using a comma: `GET https://api.prospect.io/public/v1/prospects?include=organization,creator`
 
 ```shell
 # RETURNS

--- a/source/includes_main/_organizations.md
+++ b/source/includes_main/_organizations.md
@@ -1,0 +1,264 @@
+# Organizations
+## The organization object
+```
+# EXAMPLE OBJECT
+```
+
+```json
+{
+  "data": {
+    "id": "1",
+    "type": "organizations",
+    "attributes": {
+      "name": "Prospect.io",
+      "description": null,
+      "website": "https://prospect.io",
+      "email": "contact@prospect.io",
+      "phone": "+32-481-754-301",
+      "country": "Belgium",
+      "state": "Walloon Brabant",
+      "city": "Wavre",
+      "address": "Wavre",
+      "c_custom_field_a": "Hot lead",
+      "created_from": "extension",
+      "archived": true,
+      "lists": ["Belgium", "IT"],
+      "created_at": "2015-08-15T16:48:46+02:00",
+      "updated_at": "2016-11-25T12:40:46+01:00"
+    }
+  }
+}
+```
+
+### Object attributes
+Attribute | Filterable? | Description
+--------- | ---------- | -----------
+id | **yes** | **integer** <br />A unique identifier for the organization
+name | **yes** | **string** <br />The name of the organization
+website | **yes** | **string** <br />The organization's website
+description | **yes** | **string** <br />The organization's description
+email | **yes** | **string** <br />The organization's contact email 
+phone | **yes** | **string** <br />The organization's contact phone number
+country | **yes** | **string** <br />The organization's country
+city | **yes** | **string** <br />The organization's city
+state | **yes** | **string** <br />The organization's state
+address | **yes** |**string** <br />The organization's full address
+archived | **yes** | **boolean** <br />Whether or not the organization is archived
+lists | no | **string[]** <br /> Name of the lists of the organization
+created_at | no | **datetime** <br />ISO 8601 format with timezone offset
+updated_at | no | **datetime** <br />ISO 8601 format with timezone offset
+
+### Custom Fields
+
+Custom fields can be used as normal attributes by using their `identifier` as attribute key, see the `c_custom_field_a` example in the above payload.
+
+You can retrieve the list of your custom fields by using the [custom fields index endpoint](#list-custom-fields).
+
+They accept a value depending on [their format](#the-custom-field-object)
+
+### Relationships
+Object | Description
+--------- | -----------
+creator | The [user](#users) who created the organization
+updater | The [user](#users) who updated the organization
+
+
+## Create an organization
+```shell
+# DEFINITION
+POST https://api.organization.io/public/v1/organizations
+
+# EXAMPLE
+curl -X POST "https://api.organization.io/public/v1/organizations" \
+-H "Authorization: your_api_key" \
+-H "Content-Type: application/vnd.api+json; charset=utf-8" \
+-d '{
+  "data": {
+    "type": "organizations",
+    "attributes": {
+      "name": "Prospect.io",
+      "c_custom_field_a": "Hot lead"
+    }
+  }
+}'
+```
+
+This will create a new organization. If you don't set the `responsible_id` parameter then the user who performed the action will be assigned as the responsible user.
+
+### Parameters
+Parameter | Default | Description
+--------- | ------- | ------------
+id | *NULL* | A unique identifier for the organization
+name | *NULL* | The name of the organization
+website | *NULL* | The organization's website
+description | *NULL* | The organization's description
+email | *NULL* | The organization's contact email 
+phone | *NULL* | The organization's contact phone number
+country | *NULL* | The organization's country
+city | *NULL* | The organization's city
+state | *NULL* | The organization's state
+address | *NULL* |The organization's full address
+archived | *NULL* | Whether or not the organization is archived
+lists | *NULL* | Name of the lists of the organization
+created_at | *NULL* | ISO 8601 format with timezone offset
+updated_at | *NULL* | ISO 8601 format with timezone offset
+
+
+### Returns
+Returns the [organization object](#the-organization-object).
+
+## Retrieve an organization
+```shell
+# DEFINITION
+GET https://api.organization.io/public/v1/organizations/{ORGANIZATION_ID}
+
+# EXAMPLE
+curl -X GET "https://api.organization.io/public/v1/organizations/1" \
+-H "Authorization: your_api_key" \
+-H "Content-Type: application/vnd.api+json; charset=utf-8"
+```
+
+### Parameters
+Parameter | Description
+--------- | -----------
+id<br />**required** - *integer* | The ID of the organization to retrieve
+
+### Returns
+Returns the [organization object](#the-organization-object).
+
+## Update an organization
+```shell
+# DEFINITION
+PATCH https://api.organization.io/public/v1/organizations/{ORGANIZATION_ID}
+
+# EXAMPLE
+curl -X PATCH "https://api.organization.io/public/v1/organizations/1" \
+-H "Authorization: your_api_key" \
+-H "Content-Type: application/vnd.api+json; charset=utf-8" \
+-d '{
+  "data": {
+    "type": "organizations",
+    "attributes": {
+      "name": "Prospect.io", 
+      "c_custom_field_a": "Hot lead"
+    }
+  }
+}'
+```
+
+Updates the specified organization by setting the values of the parameters passed. Any parameters not provided will be left unchanged.
+
+### Parameters
+Parameter | Description
+--------- | -----------
+id | A unique identifier for the organization
+name | The name of the organization
+website | The organization's website
+description | The organization's description
+email | The organization's contact email 
+phone | The organization's contact phone number
+country | The organization's country
+city | The organization's city
+state | The organization's state
+address | The organization's full address
+archived | Whether or not the organization is archived
+lists | Name of the lists of the organization
+created_at | ISO 8601 format with timezone offset
+updated_at | ISO 8601 format with timezone offset
+
+### Returns
+Returns the [organization object](#the-organization-object).
+
+## Delete an organization
+```shell
+# DEFINITION
+DELETE https://api.organization.io/public/v1/organizations/{ORGANIZATION_ID}
+
+# EXAMPLE
+curl -X DELETE "https://api.organization.io/public/v1/organizations/1" \
+-H "Authorization: your_api_key" \
+-H "Content-Type: application/vnd.api+json; charset=utf-8"
+```
+
+> The above command returns JSON structured like this:
+
+```json
+{
+  "data": {
+    "id": "1",
+    "type": "organizations"
+  }
+}
+```
+
+Permanently deletes an organization. It cannot be undone.
+
+<aside class="warning">
+Warning — Deleting an organization will also delete all history with this organization (messages, replies, etc.)
+</aside>
+
+### Parameters
+Parameter | Required? | Type | Description
+--------- | --------- | -----| -----------
+id | **yes** | integer | The ID of the organization to delete
+
+### Returns
+Returns an object containing the organization ID.
+
+## List organizations
+
+```shell
+# DEFINITION
+GET https://api.organization.io/public/v1/organizations
+
+# EXAMPLE
+curl -X GET "https://api.organization.io/public/v1/organizations" \
+-H "Authorization: your_api_key" \
+-H "Content-Type: application/vnd.api+json; charset=utf-8"
+```
+
+> The above command returns JSON structured like this:
+
+```json
+{
+  "data": [
+    {
+      "id": "1",
+      "type": "organizations",
+      "attributes": {
+        ...
+      },
+      "relationships": {
+        "responsible": {
+          "data": {
+            ...
+          }
+        }
+      }
+    },
+    {
+      "id": "2",
+      "type": "organizations",
+      "attributes": {
+        ...
+      },
+      "relationships": {
+        "responsible": {
+          "data": {
+            ...
+          }
+        }
+      }
+    }
+  ],
+  "links": {
+    "self": "https://api.organization.io/public/v1/organizations/?page%5Bnumber%5D=1&page%5Bsize%5D=100",
+    "next": "https://api.organization.io/public/v1/organizations/?page%5Bnumber%5D=2&page%5Bsize%5D=100",
+    "last": "https://api.organization.io/public/v1/organizations/?page%5Bnumber%5D=5&page%5Bsize%5D=100"
+  }
+}
+```
+
+Returns a list of organizations.
+
+This list is [paginated](#pagination) by 100 records. It can also be [sorted](#sorting) or [filtered](#filtering).

--- a/source/includes_main/_organizations.md
+++ b/source/includes_main/_organizations.md
@@ -83,12 +83,11 @@ curl -X POST "https://api.organization.io/public/v1/organizations" \
 }'
 ```
 
-This will create a new organization. If you don't set the `responsible_id` parameter then the user who performed the action will be assigned as the responsible user.
+This will create a new organization. 
 
 ### Parameters
 Parameter | Default | Description
 --------- | ------- | ------------
-id | *NULL* | A unique identifier for the organization
 name | *NULL* | The name of the organization
 website | *NULL* | The organization's website
 description | *NULL* | The organization's description
@@ -151,7 +150,7 @@ Updates the specified organization by setting the values of the parameters passe
 ### Parameters
 Parameter | Description
 --------- | -----------
-id | A unique identifier for the organization
+id<br />**required** - *integer* | A unique identifier for the organization
 name | The name of the organization
 website | The organization's website
 description | The organization's description

--- a/source/includes_main/_organizations.md
+++ b/source/includes_main/_organizations.md
@@ -192,9 +192,6 @@ curl -X DELETE "https://api.organization.io/public/v1/organizations/1" \
 
 Permanently deletes an organization. It cannot be undone.
 
-<aside class="warning">
-Warning — Deleting an organization will also delete all history with this organization (messages, replies, etc.)
-</aside>
 
 ### Parameters
 Parameter | Required? | Type | Description

--- a/source/includes_main/_prospects.md
+++ b/source/includes_main/_prospects.md
@@ -13,9 +13,7 @@
       "email": "vincenzo@prospect.io",
       "first_name": "Vincenzo",
       "last_name": "Ruggiero",
-      "organisation_name": "Prospect.io",
       "description": null,
-      "domain": "https://prospect.io",
       "jobtitle": "CEO",
       "linkedin_profile": "https://www.linkedin.com/in/vincenzor",
       "phone": "+32-481-754-301",
@@ -52,6 +50,12 @@
           "id": "2",
           "type": "users"
         }
+      },
+      "organization": {
+        "data": {
+          "id": "2",
+          "type": "organizations"
+        }
       }
     }
   }
@@ -65,9 +69,7 @@ id | **yes** | **integer** <br />A unique identifier for the prospect
 email | **yes** | **string** <br />The prospect's email address
 first_name | **yes** | **string** <br />The prospect's first name
 last_name | **yes** | **string** <br />The prospect's last name
-organisation_name | no | **string** <br />The prospect's company name
 description | no | **string** <br />A text description of the prospect
-domain | **yes** | **string** <br />The prospect's website
 jobtitle | **yes** | **string** <br />The prospect's job title
 linkedin_profile | no |**string** <br />A link to the prospect's LinkedIn profile
 phone | **yes** | **string** <br />The prospect's phone number
@@ -105,6 +107,7 @@ They accept a value depending on [their format](#the-custom-field-object)
 Object | Description
 --------- | -----------
 creator | The [user](#users) who created the prospect
+organization | The [organization](#organizations) of this prospect
 responsible | The [user](#users) responsible of the prospect
 
 
@@ -138,9 +141,7 @@ Parameter | Default | Description
 email<br />**required** - *string* | / | The prospect's email
 first_name<br />*string* | *NULL* | The prospect's first name
 last_name<br />*string* | *NULL* | The prospect's last name
-organisation_name<br />*string* | *NULL* | The prospect's company name
 description<br />*string* | *NULL* | A text description of the prospect
-domain<br />*string* | *NULL* | The prospect's website
 jobtitle<br />*string* | *NULL* | The prospect's job title
 linkedin_profile<br />*string* | *NULL* | A link to the prospect's LinkedIn profile
 phone<br />*string* | *NULL* | The prospect's phone number
@@ -151,6 +152,7 @@ city<br />*string* | *NULL* | The prospect's city
 industry<br />*string* | *NULL* | The prospect's industry
 lists<br />*string[]* | *NULL* | Name of the lists where to save the prospect<br/>(note: we will create the lists if they don't exist)
 responsible_id<br />*integer* | ID of the user who created the prospect | The ID of the user responsible for this prospect
+organization_id<br />*integer* | ID of the organization this prospect belongs to | See [create an organization](#create-an-organization)
 
 ### Returns
 Returns the [prospect object](#the-prospect-object).
@@ -204,9 +206,7 @@ id<br />**required** - *integer* | The ID of the prospect to update
 email<br />**required** - *string* | The prospect's email
 first_name<br />*string* | The prospect's first name
 last_name<br />*string* | The prospect's last name
-organisation_name<br />*string* | The prospect's company name
 description<br />*string* | A text description of the prospect
-domain<br />*string* | The prospect's website
 jobtitle<br />*string* | The prospect's job title
 linkedin_profile<br />*string* | A link to the prospect's LinkedIn profile
 phone<br />*string* | The prospect's phone number
@@ -217,6 +217,7 @@ city<br />*string* | *NULL* | The prospect's city
 industry<br />*string* | The prospect's industry
 lists<br />*string[]* | Name of the lists where to save the prospect<br/>(note: we will create the lists if they don't exist)
 responsible_id<br />*integer* | The ID of the user responsible for this prospect
+organization_id<br />*integer* | ID of the organization this prospect belongs to | See [create an organization](#create-an-organization)
 
 ### Returns
 Returns the [prospect object](#the-prospect-object).

--- a/source/includes_main/_prospects.md
+++ b/source/includes_main/_prospects.md
@@ -23,7 +23,6 @@
       "country": "Belgium",
       "state": "Walloon Brabant",
       "city": "Wavre",
-      "industry": "IT",
       "c_custom_field_a": "Hot lead",
       "created_from": "extension",
       "last_emailed_at": null,
@@ -67,7 +66,6 @@ first_name | **yes** | **string** <br />The prospect's first name
 last_name | **yes** | **string** <br />The prospect's last name
 organisation_name | no | **string** <br />The prospect's company name
 description | no | **string** <br />A text description of the prospect
-domain | **yes** | **string** <br />The prospect's website
 jobtitle | **yes** | **string** <br />The prospect's job title
 linkedin_profile | no |**string** <br />A link to the prospect's LinkedIn profile
 phone | **yes** | **string** <br />The prospect's phone number
@@ -75,7 +73,6 @@ title | **yes** | **string** <br />The prospect's title of civility
 country | **yes** | **string** <br />The prospect's country
 state | **yes** | **string** <br />The prospect's state or region
 city | **yes** | **string** <br />The prospect's city
-industry | **yes** | **string** <br />The prospect's industry
 created_from | no | **string** <br />The source of the prospect. Can be `web`, `extension`, `api` or `import`
 last_emailed_at | no | **datetime** <br />The date and time of the last email sent to this prospect in ISO 8601 format with timezone offset
 converted | **yes** | **boolean** <br />Whether or not the prospect is marked as converted
@@ -140,7 +137,6 @@ first_name<br />*string* | *NULL* | The prospect's first name
 last_name<br />*string* | *NULL* | The prospect's last name
 organisation_name<br />*string* | *NULL* | The prospect's company name
 description<br />*string* | *NULL* | A text description of the prospect
-domain<br />*string* | *NULL* | The prospect's website
 jobtitle<br />*string* | *NULL* | The prospect's job title
 linkedin_profile<br />*string* | *NULL* | A link to the prospect's LinkedIn profile
 phone<br />*string* | *NULL* | The prospect's phone number
@@ -148,7 +144,6 @@ title<br />*string* | *NULL* | The prospect's title of civility
 country<br />*string* | *NULL* | The prospect's country
 state<br />*string* | *NULL* | The prospect's state or region
 city<br />*string* | *NULL* | The prospect's city
-industry<br />*string* | *NULL* | The prospect's industry
 lists<br />*string[]* | *NULL* | Name of the lists where to save the prospect<br/>(note: we will create the lists if they don't exist)
 responsible_id<br />*integer* | ID of the user who created the prospect | The ID of the user responsible for this prospect
 
@@ -206,7 +201,6 @@ first_name<br />*string* | The prospect's first name
 last_name<br />*string* | The prospect's last name
 organisation_name<br />*string* | The prospect's company name
 description<br />*string* | A text description of the prospect
-domain<br />*string* | The prospect's website
 jobtitle<br />*string* | The prospect's job title
 linkedin_profile<br />*string* | A link to the prospect's LinkedIn profile
 phone<br />*string* | The prospect's phone number
@@ -214,7 +208,6 @@ title<br />*string* | The prospect's title of civility
 country<br />*string* | The prospect's country
 state<br />*string* | *NULL* | The prospect's state or region
 city<br />*string* | *NULL* | The prospect's city
-industry<br />*string* | The prospect's industry
 lists<br />*string[]* | Name of the lists where to save the prospect<br/>(note: we will create the lists if they don't exist)
 responsible_id<br />*integer* | The ID of the user responsible for this prospect
 

--- a/source/includes_main/_prospects.md
+++ b/source/includes_main/_prospects.md
@@ -23,6 +23,7 @@
       "country": "Belgium",
       "state": "Walloon Brabant",
       "city": "Wavre",
+      "industry": "IT",
       "c_custom_field_a": "Hot lead",
       "created_from": "extension",
       "last_emailed_at": null,
@@ -66,6 +67,7 @@ first_name | **yes** | **string** <br />The prospect's first name
 last_name | **yes** | **string** <br />The prospect's last name
 organisation_name | no | **string** <br />The prospect's company name
 description | no | **string** <br />A text description of the prospect
+domain | **yes** | **string** <br />The prospect's website
 jobtitle | **yes** | **string** <br />The prospect's job title
 linkedin_profile | no |**string** <br />A link to the prospect's LinkedIn profile
 phone | **yes** | **string** <br />The prospect's phone number
@@ -73,6 +75,7 @@ title | **yes** | **string** <br />The prospect's title of civility
 country | **yes** | **string** <br />The prospect's country
 state | **yes** | **string** <br />The prospect's state or region
 city | **yes** | **string** <br />The prospect's city
+industry | **yes** | **string** <br />The prospect's industry
 created_from | no | **string** <br />The source of the prospect. Can be `web`, `extension`, `api` or `import`
 last_emailed_at | no | **datetime** <br />The date and time of the last email sent to this prospect in ISO 8601 format with timezone offset
 converted | **yes** | **boolean** <br />Whether or not the prospect is marked as converted
@@ -137,6 +140,7 @@ first_name<br />*string* | *NULL* | The prospect's first name
 last_name<br />*string* | *NULL* | The prospect's last name
 organisation_name<br />*string* | *NULL* | The prospect's company name
 description<br />*string* | *NULL* | A text description of the prospect
+domain<br />*string* | *NULL* | The prospect's website
 jobtitle<br />*string* | *NULL* | The prospect's job title
 linkedin_profile<br />*string* | *NULL* | A link to the prospect's LinkedIn profile
 phone<br />*string* | *NULL* | The prospect's phone number
@@ -144,6 +148,7 @@ title<br />*string* | *NULL* | The prospect's title of civility
 country<br />*string* | *NULL* | The prospect's country
 state<br />*string* | *NULL* | The prospect's state or region
 city<br />*string* | *NULL* | The prospect's city
+industry<br />*string* | *NULL* | The prospect's industry
 lists<br />*string[]* | *NULL* | Name of the lists where to save the prospect<br/>(note: we will create the lists if they don't exist)
 responsible_id<br />*integer* | ID of the user who created the prospect | The ID of the user responsible for this prospect
 
@@ -201,6 +206,7 @@ first_name<br />*string* | The prospect's first name
 last_name<br />*string* | The prospect's last name
 organisation_name<br />*string* | The prospect's company name
 description<br />*string* | A text description of the prospect
+domain<br />*string* | The prospect's website
 jobtitle<br />*string* | The prospect's job title
 linkedin_profile<br />*string* | A link to the prospect's LinkedIn profile
 phone<br />*string* | The prospect's phone number
@@ -208,6 +214,7 @@ title<br />*string* | The prospect's title of civility
 country<br />*string* | The prospect's country
 state<br />*string* | *NULL* | The prospect's state or region
 city<br />*string* | *NULL* | The prospect's city
+industry<br />*string* | The prospect's industry
 lists<br />*string[]* | Name of the lists where to save the prospect<br/>(note: we will create the lists if they don't exist)
 responsible_id<br />*integer* | The ID of the user responsible for this prospect
 

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -18,6 +18,7 @@ includes:
 includes_main:
   - account
   - prospects
+  - organizations
   - custom_fields
   - exclusion_list_items
   - lists

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -13,6 +13,7 @@ includes:
   - sorting
   - filtering
   - pagination
+  - relationships
   - errors
 
 includes_main:


### PR DESCRIPTION
Note: 

We don't introduce yet a hard link between prospect & organization (and thus still allow using organization_name, until we update zapier, etc… ) 